### PR TITLE
feat: add rotation attribute to DetectImageOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,9 @@ Tries to detect text from the given image
 
 #### DetectImageOptions
 
-| Prop              | Type                | Description                    |
-| ----------------- | ------------------- | ------------------------------ |
-| **`base64Image`** | <code>string</code> | The image to detect texts from |
+| Prop              | Type                | Description                                                                                      |
+| ----------------- | ------------------- | ------------------------------------------------------------------------------------------------ |
+| **`base64Image`** | <code>string</code> | The image to detect texts from                                                                   |
+| **`rotation`**    | <code>number</code> | The image's counter-clockwise orientation degrees. Only 0, 90, 180, 270 are supported. Default 0 |
 
 </docgen-api>

--- a/android/src/main/java/com/pantrist/ml/CapacitorPluginMlKitTextRecognition.kt
+++ b/android/src/main/java/com/pantrist/ml/CapacitorPluginMlKitTextRecognition.kt
@@ -22,6 +22,7 @@ class CapacitorPluginMlKitTextRecognition : Plugin() {
             call.reject("No image is given!")
             return
         }
+        val rotation = call.getInt("rotation") ?: 0
 
         val image: InputImage
         try {
@@ -31,7 +32,7 @@ class CapacitorPluginMlKitTextRecognition : Plugin() {
                 call.reject("Decoded image is null")
                 return
             }
-            image = InputImage.fromBitmap(decodedByte, 0);
+            image = InputImage.fromBitmap(decodedByte, rotation)
         } catch (e: IOException) {
             call.reject("Unable to parse image")
             return

--- a/ios/Plugin.xcodeproj/project.pbxproj
+++ b/ios/Plugin.xcodeproj/project.pbxproj
@@ -270,11 +270,11 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Plugin/Pods-Plugin-resources.sh",
-				"${PODS_CONFIGURATION_BUILD_DIR}/MLKitTextRecognition/GoogleMVTextDetectorResources.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/MLKitTextRecognition/LatinOCRResources.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/GoogleMVTextDetectorResources.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/LatinOCRResources.bundle",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -322,11 +322,11 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-PluginTests/Pods-PluginTests-resources.sh",
-				"${PODS_CONFIGURATION_BUILD_DIR}/MLKitTextRecognition/GoogleMVTextDetectorResources.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/MLKitTextRecognition/LatinOCRResources.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/GoogleMVTextDetectorResources.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/LatinOCRResources.bundle",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/ios/Plugin/CapacitorPluginMlKitTextRecognitionPlugin.swift
+++ b/ios/Plugin/CapacitorPluginMlKitTextRecognitionPlugin.swift
@@ -13,6 +13,7 @@ public class CapacitorPluginMlKitTextRecognitionPlugin: CAPPlugin {
             call.reject("No image is given!")
             return
         }
+        let rotation = call.getInt("rotation") ?? 0
 
         let dataDecoded : Data = Data(base64Encoded: encodedImage, options: .ignoreUnknownCharacters)!
         guard let image = UIImage(data: dataDecoded) else {
@@ -23,6 +24,7 @@ public class CapacitorPluginMlKitTextRecognitionPlugin: CAPPlugin {
         let latinOptions = TextRecognizerOptions()
         let textRecognizer = TextRecognizer.textRecognizer(options: latinOptions)
         let visionImage = VisionImage(image: image)
+        visionImage.orientation = visionImageOrientation(rotation: rotation)
 
         textRecognizer.process(visionImage) { result, error in
           guard error == nil, let result = result else {
@@ -79,6 +81,21 @@ public class CapacitorPluginMlKitTextRecognitionPlugin: CAPPlugin {
             "text": result.text,
             "blocks": textBlocks
           ])
+        }
+    }
+
+    public func visionImageOrientation(rotation: Int) -> UIImage.Orientation {
+        switch rotation {
+        case 0:
+            return .up
+        case 90:
+            return .left
+        case 180:
+            return .down
+        case 270:
+            return .right
+        default:
+            return .up
         }
     }
 }

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -5,7 +5,7 @@ def capacitor_pods
   use_frameworks!
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
-  pod 'GoogleMLKit/TextRecognition','2.2.0'
+  pod 'GoogleMLKit/TextRecognition','3.2.0'
 end
 
 target 'Plugin' do

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -12,6 +12,10 @@ export interface DetectImageOptions {
    * The image to detect texts from
    */
   base64Image: string;
+  /**
+   * The image's counter-clockwise orientation degrees. Only 0, 90, 180, 270 are supported. Default 0
+   */
+  rotation?: number;
 }
 
 export interface TextDetectionResult {


### PR DESCRIPTION
Hi, 
I'd like to add an optional rotation parameter to specify the image rotation. The default value is 0 so it should be backwards compatible.