### PR TITLE
chore(renovate): use shared org renovate-config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "github>Pantrist-dev/renovate-config"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
Extends the org's shared `renovate-config` repo instead of Renovate's default `config:recommended` preset, so this repo picks up the shared package rules (grouping, minimum release age, etc.).